### PR TITLE
Use a different vim dir, when VOOM_DIR is set

### DIFF
--- a/voom
+++ b/voom
@@ -17,6 +17,11 @@
 set -e
 
 VIM_DIR=~/dotvim
+
+test -z "$VOOM_DIR" || {
+  VIM_DIR=$VOOM_DIR
+}
+
 MANIFEST="$VIM_DIR/plugins"
 BUNDLE_DIR="$VIM_DIR/bundle"
 COMMENT='^#'


### PR DESCRIPTION
Currently voom requires your vim files to be located in ~/dotvim. Not
everybody uses this location and to make voom work, you need to add a
symlink in your home folder.

With this change you can specify your own vim directory with an
environment variable. As an example you can use the following as an
alias to voom:

    env VOOM_DIR=~/.vim voom

Or set VOOM_DIR in you ~/.bashrc

    export VOOM_DIR=~/.vim

I did not use VIM_DIR, because it does not belong to voom and might
break other scripts. It also is not really clear, what VIM_DIR contains.
It might contain the path of your vim configuration or the path to the
vim executable.

---

Please note, that I didn’t update any documentation file.