### PR TITLE
Added support for full URLs (including GitLab)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Here's an example of a manifest:
 # Declare repos on GitHub with: username/repo.
 tpope/vim-fugitive
 
+# Declare repos on Gitlab or others with full URL:
+https://github.com/tpope/vim-obsession
+https://gitlab.com/hugoh/vim-auto-obsession
+
 # Declare repos on your file system with the absolute path.
 /Users/andy/code/src/vim-gitgutter
 ```

--- a/voom
+++ b/voom
@@ -46,10 +46,13 @@ edit_manifest() {
   "${EDITOR:-vim}" "$MANIFEST"
 }
 
-is_remote_repo() {
-  local slashes="${1//[^\/]}"
+remote_repo() {
+  local repo=$1
+  [[ $repo = http://* || $repo = https://* ]] && printf "%s.git" "$repo" && return
+  local slashes="${repo//[^\/]}"
   local count="${#slashes}"
-  [ "$count" -eq 1 ]
+  [ "$count" -eq 1 ] && printf "https://github.com/%s.git" "$repo" && return
+  # Otherwise, it's a local repo
 }
 
 install_plugin() {
@@ -59,8 +62,9 @@ install_plugin() {
   local plugin_name=${line##*/}
 
   [ -d "$PLUGINS_DIR/$plugin_name" ] || {
-    if is_remote_repo "$line"; then
-      git clone --depth 1 "https://github.com/$line.git" "$PLUGINS_DIR/$plugin_name" >/dev/null 2>&1
+    local repo=$(remote_repo "$line")
+    if [[ -n "$repo" ]]; then
+      git clone --depth 1 "$repo" "$PLUGINS_DIR/$plugin_name" >/dev/null 2>&1
     else
       ln -nfs "$line" "$PLUGINS_DIR/$plugin_name"
     fi


### PR DESCRIPTION
Voom only allows getting plugins from Github.

This PR allows plugins to be full `http`/`https` URLs, allowing fetching them from GitLab or other places. I modified `is_remote_repo` to return a full URL for a valid remote repo.