### PR TITLE
Fix: matches substring

### DIFF
--- a/voom
+++ b/voom
@@ -76,7 +76,7 @@ uninstall_plugin() {
   local dir="$1"
   [ -z "$dir" ] && return 1
   plugin_name=${dir##*/}
-  (grep -v "$COMMENT" "$MANIFEST" | grep -q "$plugin_name") || {
+  (grep -v "$COMMENT" "$MANIFEST" | grep -q "/$plugin_name") || {
     rm -rf "$dir"
     echo "uninstalled $plugin_name"
   }


### PR DESCRIPTION
Because the grep for returning non-commented plugins returns user/repo and then grep against only repo, we will get a substring match.

So..

user/vim-lsp

and user/lsp

Will clash, because "lsp" matches in "vim-lsp" and hence "lsp" is not removed.

A quick solution is to match incl forward-slash.