### PR TITLE
Fix: uninstall_plugin: substring match

### DIFF
--- a/voom
+++ b/voom
@@ -76,7 +76,7 @@ uninstall_plugin() {
   local dir="$1"
   [ -z "$dir" ] && return 1
   plugin_name=${dir##*/}
-  (grep -v "$COMMENT" "$MANIFEST" | grep -q "/$plugin_name") || {
+  (grep -v "$COMMENT" "$MANIFEST" | grep -q "/${plugin_name}$") || {
     rm -rf "$dir"
     echo "uninstalled $plugin_name"
   }


### PR DESCRIPTION
:) Its the other way this time (hah).

If you had
`~/src/vim/lsp`
before

and now remove/comment that out

`~/src/vim/lsp-test` matches 🤦‍♂️ no plugin is removed.