### PR TITLE
voom: XDG_CONFIG_HOME fallback

### DIFF
--- a/voom
+++ b/voom
@@ -24,7 +24,7 @@ fi
 
 MANIFEST="$(find -L "$VIM_DIR/plugins" "$HOME/.vim/plugins" \
   "${XDG_CONFIG_HOME:-$HOME/.config}/vim/plugins" \
-  -maxdepth 0 -type f -readable 2>/dev/null | head -n1)"
+  -type f -readable 2>/dev/null | head -n1)"
 
 VIM_DIR="$(dirname "$MANIFEST")"
 

--- a/voom
+++ b/voom
@@ -22,11 +22,13 @@ if [ -n "$VIM_BUNDLE_DIR" ]; then
   PLUGINS_DIR="$VIM_BUNDLE_DIR"
 fi
 
-MANIFEST="$(find -L "$VIM_DIR/plugins" "$HOME/.vim/plugins" \
-  "${XDG_CONFIG_HOME:-$HOME/.config}/vim/plugins" \
-  -type f -readable 2>/dev/null | head -n1)"
-
-VIM_DIR="$(dirname "$MANIFEST")"
+for dir in "${VIM_DIR:-$HOME/.vim}" "${XDG_CONFIG_HOME:-$HOME/.config}/vim"; do
+  VIM_DIR="$dir"
+  MANIFEST="$dir/plugins"
+  if [ -r "$MANIFEST" ]; then
+    break
+  fi
+done
 
 PLUGINS_DIR="${VIM_PLUGINS_DIR:-$VIM_DIR/pack/voom/start}"
 COMMENT='#'

--- a/voom
+++ b/voom
@@ -22,8 +22,12 @@ if [ -n "$VIM_BUNDLE_DIR" ]; then
   PLUGINS_DIR="$VIM_BUNDLE_DIR"
 fi
 
-VIM_DIR="${VIM_DIR:-$HOME/.vim}"
-MANIFEST="$VIM_DIR/plugins"
+MANIFEST="$(find -L "$VIM_DIR/plugins" "$HOME/.vim/plugins" \
+  "${XDG_CONFIG_HOME:-$HOME/.config}/vim/plugins" \
+  -maxdepth 0 -type f -readable 2>/dev/null | head -n1)"
+
+VIM_DIR="$(dirname "$MANIFEST")"
+
 PLUGINS_DIR="${VIM_PLUGINS_DIR:-$VIM_DIR/pack/voom/start}"
 COMMENT='#'
 action="$1"


### PR DESCRIPTION
Follows `:help vimrc` search order (`$HOME/.vim` or `$XDG_CONFIG_HOME`).
 
If `$XDG_CONFIG_HOME` doesn't exist then defaults to `$HOME/.config/vim`. Vim also finds it if `XDG_CONFIG_HOME` does not exist, but directory is still present.

Override with `VIM_DIR` env variable.

**Example:**
```console
$ voom  # only .config/vim/plugins exists
VIM_DIR: /home/dza/.config/vim
MANIFEST: /home/dza/.config/vim/plugins

$ touch .vim/plugins
$ voom  # $HOME/.vim comes before `$HOME/.config/vim` or `$XDG_CONFIG_HOME/vim`
VIM_DIR: /home/dza/.vim
MANIFEST: /home/dza/.vim/plugins

$ VIM_DIR="$HOME/.config/vim" voom  # override with VIM_DIR env (.vim/plugins exists)
VIM_DIR: /home/dza/.config/vim
MANIFEST: /home/dza/.config/vim/plugins

$ XDG_CONFIG_HOME="$HOME/.config" voom  # if XDG_CONFIG_HOME unset defaults to $HOME/.config
VIM_DIR: /home/dza/.config/vim
MANIFEST: /home/dza/.config/vim/plugins
```